### PR TITLE
Clean up generation of PDFs of meetings

### DIFF
--- a/20240828.md
+++ b/20240828.md
@@ -326,12 +326,14 @@ There are no new statistics, beyond those reported above.
 # Actions
 
 2024-08-14
+
 - **Paolo** Run Nathan's memcpy benchmark.
   - **COMPLETE** See above.
 - **Jeremy** to put Embecosm's `memcpy` benchmark scripts in the public repository.
   - **COMPLETE** See commit [#ccc9dd1](https://github.com/embecosm/rise-rvv-tcg-qemu-tooling/commit/ccc9dd11d5e1c89b9303715f35e0976286c2586e) in the [`rise-rvv-tcg-qemu-tooling`](https://github.com/embecosm/rise-rvv-tcg-qemu-tooling) repository.  This includes the ability to run the Bionic variant and the ability to run Linux _perf_ on benchmarks.
 
 2024-07-31
+
 - **Max** Add his SPEC CPU benchmark scripts to the above mentioned repository, so Embecosm can reproduce his results.
 - **Paolo** Create a reference set of statically linked SPEC CPU 2017 binaries to be made available to those who need them.
   - **ON HOLD**. Lower priority.
@@ -339,10 +341,12 @@ There are no new statistics, beyond those reported above.
   - **ON HOLD** lower priority.
 
 2024-07-17
+
 - **Paolo** Account for regular checks on comments and time required to address feedback on the patch.
   - Review work in progress
 
 2024-06-05
+
 - **Paolo** Check behavior of QEMU with tail bytes.
   - Deferred to prioritize host targeted optimization work.
 
@@ -388,6 +392,7 @@ Our current set of agreed priorities are as follows
 - vector load/store ops for Intel AVX10
 
 For each of these there will be an analysis phase and an optimization phase, leading to the following set of work packages.
+
 - WP0: Infrastructure
 - WP1: Analysis of vector load/store ops on x86_64 AVX
 - WP2: Optimization of vector load/store ops on x86_64 AVX

--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,25 @@
 
 allmd = $(wildcard 2*.md)
 allpdf = $(allmd:.md=.pdf)
+allodt = $(allmd:.md=.odt)
 
 %.pdf: %.md
-	pandoc --dpi=300 --reference-doc=./reference.odt -o $*.odt $<
+	$(RM) tmpfile.md
+	sed < $< > tmpfile.md -e 's/\.svg)/.png)/'
+	pandoc --dpi=300 --reference-doc=./reference.odt -o $*.odt tmpfile.md
 	lowriter --headless --convert-to pdf $*.odt
+	$(RM) tmpfile.md
 
 
 .PHONY: all
-all: pdf
+all:
+	$(MAKE) -C images all
+	$(MAKE) pdf
 
 .PHONY: pdf
 pdf: $(allpdf)
 
 .PHONY: clean
 clean:
-	$(RM) 2*.pdf 2*.odt
+	$(MAKE) -C images clean
+	$(RM) $(allpdf) $(allodt)

--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,0 +1,2 @@
+# Generated images
+*.png

--- a/images/Makefile
+++ b/images/Makefile
@@ -1,0 +1,23 @@
+# Makefile to generate PNG from SVG via Inkscape
+
+# Copyright (C) 2024 Embecosm Limited (www.embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+allsvg = $(wildcard *.svg)
+allpng = $(allsvg:.svg=.png)
+
+%.png: %.svg
+	inkscape -d 600 $< -o $*.png
+
+
+.PHONY: all
+all: png
+
+.PHONY: png
+png: $(allpng)
+
+.PHONY: clean
+clean:
+	$(RM) $(allpng)


### PR DESCRIPTION
SVG does not always render wll from ODT to PDF, so we conver to PNG.  We take the opportunity to fix some trivial issues in the most recent fortnighly report.

	* 20240828.md: Minor fixes to layout.
	* Makefile: Generate to PDF using PNG images.
	* images/.gitignore: Created.
	* images/Makefile: Created.