### PR TITLE
Update to RISE QEMU report for 15 Jan 2025

### DIFF
--- a/20250115.md
+++ b/20250115.md
@@ -8,6 +8,7 @@
 - Patch 2 (large vectors unit stride loads/stores).
   - Minor fixes posted to address [Richard Henderson's review](https://lists.gnu.org/archive/html/qemu-devel/2025-01/msg01147.html).
   - [Updated patch](https://lists.gnu.org/archive/html/qemu-devel/2025-01/msg01332.html), no further responses.
+  - **COMPLETE.**
 
 ## Milestone 3
 


### PR DESCRIPTION
	* 20250115.md: Minor omission corrected.